### PR TITLE
병목코드 최적화

### DIFF
--- a/src/pages/Card.tsx
+++ b/src/pages/Card.tsx
@@ -82,21 +82,22 @@ export default function CardPage() {
 }
 
 function removeHtmlTags(text: string | undefined) {
-  let output = '';
-  if (text)
-    for (let i = 0; i < text.length; i++) {
-      if (text[i] === '<') {
-        for (let j = i + 1; j < text.length; j++) {
-          if (text[j] === '>') {
-            i = j;
-            break;
-          }
-        }
-      } else {
-        output += text[i];
-      }
-    }
-  return output;
+  // let output = '';
+  // if (text)
+  //   for (let i = 0; i < text.length; i++) {
+  //     if (text[i] === '<') {
+  //       for (let j = i + 1; j < text.length; j++) {
+  //         if (text[j] === '>') {
+  //           i = j;
+  //           break;
+  //         }
+  //       }
+  //     } else {
+  //       output += text[i];
+  //     }
+  //   }
+  // return output;
+  if (text) return text.replace(/<\/?[^>]+(>|$)/g, '');
 }
 
 function IconCheck() {


### PR DESCRIPTION
html 태그를 문자열로 받아왔을 때, 열고 닫는 태그를 삭제해주는 함수를 정규표현식으로 만들어서 성능을 개선함 